### PR TITLE
chore(nav): remove useless github link

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -42,14 +42,6 @@ export function MainNav() {
         >
           Playground
         </Link>
-        <Link
-          href='https://github.com/ada-url/ada'
-          className={cn(
-            'hidden text-foreground/60 transition-colors hover:text-foreground/80 lg:block',
-          )}
-        >
-          GitHub
-        </Link>
       </nav>
     </div>
   )

--- a/config/docs.ts
+++ b/config/docs.ts
@@ -15,11 +15,6 @@ export const docsConfig: DocsConfig = {
       title: 'Playground',
       href: '/playground',
     },
-    {
-      title: 'GitHub',
-      href: 'https://github.com/ada-url/ada',
-      external: true,
-    },
   ],
   sidebarNav: [
     {


### PR DESCRIPTION
We have already on on header so it's don't need to put everywhere