### PR TITLE
fix: add dark styling to emphasized Link on index

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -54,7 +54,7 @@ export default function IndexPage() {
             On a benchmark where we need to validate and normalize{' '}
             <Link
               href='https://github.com/ada-url/url-various-datasets/tree/main/top100'
-              className='text-black font-bold underline'
+              className='text-black dark:text-white font-bold underline'
             >
               thousands of URLs found on popular websites
             </Link>{' '}


### PR DESCRIPTION
<details>
<summary>before/after</summary>

before: ![image](https://github.com/ada-url/website/assets/59253100/59528a98-e309-4b05-a627-da002caf4a12)

after: ![image](https://github.com/ada-url/website/assets/59253100/96a05d68-74f1-46fe-b2aa-3aaabadc38e1)

</details>