### PR TITLE
Fix Astro build

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -4,6 +4,14 @@ import { defineConfig } from 'astro/config'
 // https://astro.build/config
 export default defineConfig({
   srcDir: './astro',
+  vite: {
+    build: {
+      rollupOptions: {
+        // For some reason, the build crashes without this
+        external: ['sharp'],
+      },
+    },
+  },
   integrations: [
     starlight({
       // https://starlight.astro.build/reference/configuration

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -31,7 +31,16 @@
     "lineWidth": 100
   },
   "files": {
-    "ignore": ["node_modules", "public", ".next", ".contentlayer", "lib/wasm", ".vercel"]
+    "ignore": [
+      "node_modules",
+      "public",
+      ".next",
+      ".contentlayer",
+      "lib/wasm",
+      ".vercel",
+      ".astro",
+      "dist"
+    ]
   },
   "javascript": {
     "formatter": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "dev-astro": "astro dev",
     "build-astro": "astro build",
-    "lint": "biome check . && biome format .",
-    "lint-fix": "biome check . --write --unsafe && biome format . --write"
+    "lint": "biome check .",
+    "lint-fix": "biome check . --write --unsafe"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.26.1
         version: 0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))
+      '@astrojs/starlight-tailwind':
+        specifier: ^2.0.3
+        version: 2.0.3(@astrojs/starlight@0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2)))(@astrojs/tailwind@5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3))(tailwindcss@3.3.3)
+      '@astrojs/tailwind':
+        specifier: ^5.1.0
+        version: 5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3)
       '@radix-ui/react-accordion':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -186,10 +192,23 @@ packages:
   '@astrojs/sitemap@3.1.6':
     resolution: {integrity: sha512-1Qp2NvAzVImqA6y+LubKi1DVhve/hXXgFvB0szxiipzh7BvtuKe4oJJ9dXSqaubaTkt4nMa6dv6RCCAYeB6xaQ==}
 
+  '@astrojs/starlight-tailwind@2.0.3':
+    resolution: {integrity: sha512-ZwbdXS/9rxYlo3tKZoTZoBPUnaaqek02b341dHwOkmMT0lIR2w+8k0mRUGxnRaYtPdMcaL+nYFd8RUa8sjdyRg==}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.9.0'
+      '@astrojs/tailwind': ^5.0.0
+      tailwindcss: ^3.3.3
+
   '@astrojs/starlight@0.26.1':
     resolution: {integrity: sha512-0qNYWZJ+ZOdSfM7du6fGuwUhyTHtAeRIl0zYe+dF0TxDvcakplO1SYLbGGX6lEVYE3PdBne7dcJww85bXZJIIQ==}
     peerDependencies:
       astro: ^4.8.6
+
+  '@astrojs/tailwind@5.1.0':
+    resolution: {integrity: sha512-BJoCDKuWhU9FT2qYg+fr6Nfb3qP4ShtyjXGHKA/4mHN94z7BGcmauQK23iy+YH5qWvTnhqkd6mQPQ1yTZTe9Ig==}
+    peerDependencies:
+      astro: ^3.0.0 || ^4.0.0
+      tailwindcss: ^3.0.24
 
   '@astrojs/telemetry@3.1.0':
     resolution: {integrity: sha512-/ca/+D8MIKEC8/A9cSaPUqQNZm+Es/ZinRv0ZAzvu2ios7POQSsVD+VOj7/hypWNsNM3T7RpfgNq7H2TU1KEHA==}
@@ -2578,6 +2597,10 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lilconfig@3.1.2:
+    resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -3248,6 +3271,18 @@ packages:
 
   postcss-load-config@4.0.1:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+
+  postcss-load-config@4.0.2:
+    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
       postcss: '>=8.0.9'
@@ -4032,6 +4067,11 @@ packages:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
     engines: {node: '>= 14'}
 
+  yaml@2.5.0:
+    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4131,6 +4171,12 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
+  '@astrojs/starlight-tailwind@2.0.3(@astrojs/starlight@0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2)))(@astrojs/tailwind@5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3))(tailwindcss@3.3.3)':
+    dependencies:
+      '@astrojs/starlight': 0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))
+      '@astrojs/tailwind': 5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3)
+      tailwindcss: 3.3.3
+
   '@astrojs/starlight@0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))':
     dependencies:
       '@astrojs/mdx': 3.1.3(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))
@@ -4157,6 +4203,16 @@ snapshots:
       vfile: 6.0.2
     transitivePeerDependencies:
       - supports-color
+
+  '@astrojs/tailwind@5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3)':
+    dependencies:
+      astro: 4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2)
+      autoprefixer: 10.4.16(postcss@8.4.29)
+      postcss: 8.4.29
+      postcss-load-config: 4.0.2(postcss@8.4.29)
+      tailwindcss: 3.3.3
+    transitivePeerDependencies:
+      - ts-node
 
   '@astrojs/telemetry@3.1.0':
     dependencies:
@@ -6740,6 +6796,8 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lilconfig@3.1.2: {}
+
   lines-and-columns@1.2.4: {}
 
   load-yaml-file@0.2.0:
@@ -7982,6 +8040,13 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.29
 
+  postcss-load-config@4.0.2(postcss@8.4.29):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.5.0
+    optionalDependencies:
+      postcss: 8.4.29
+
   postcss-nested@6.0.1(postcss@8.4.29):
     dependencies:
       postcss: 8.4.29
@@ -8974,6 +9039,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.3.1: {}
+
+  yaml@2.5.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,6 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.26.1
         version: 0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))
-      '@astrojs/starlight-tailwind':
-        specifier: ^2.0.3
-        version: 2.0.3(@astrojs/starlight@0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2)))(@astrojs/tailwind@5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3))(tailwindcss@3.3.3)
-      '@astrojs/tailwind':
-        specifier: ^5.1.0
-        version: 5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3)
       '@radix-ui/react-accordion':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.8)(@types/react@18.2.24)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -192,23 +186,10 @@ packages:
   '@astrojs/sitemap@3.1.6':
     resolution: {integrity: sha512-1Qp2NvAzVImqA6y+LubKi1DVhve/hXXgFvB0szxiipzh7BvtuKe4oJJ9dXSqaubaTkt4nMa6dv6RCCAYeB6xaQ==}
 
-  '@astrojs/starlight-tailwind@2.0.3':
-    resolution: {integrity: sha512-ZwbdXS/9rxYlo3tKZoTZoBPUnaaqek02b341dHwOkmMT0lIR2w+8k0mRUGxnRaYtPdMcaL+nYFd8RUa8sjdyRg==}
-    peerDependencies:
-      '@astrojs/starlight': '>=0.9.0'
-      '@astrojs/tailwind': ^5.0.0
-      tailwindcss: ^3.3.3
-
   '@astrojs/starlight@0.26.1':
     resolution: {integrity: sha512-0qNYWZJ+ZOdSfM7du6fGuwUhyTHtAeRIl0zYe+dF0TxDvcakplO1SYLbGGX6lEVYE3PdBne7dcJww85bXZJIIQ==}
     peerDependencies:
       astro: ^4.8.6
-
-  '@astrojs/tailwind@5.1.0':
-    resolution: {integrity: sha512-BJoCDKuWhU9FT2qYg+fr6Nfb3qP4ShtyjXGHKA/4mHN94z7BGcmauQK23iy+YH5qWvTnhqkd6mQPQ1yTZTe9Ig==}
-    peerDependencies:
-      astro: ^3.0.0 || ^4.0.0
-      tailwindcss: ^3.0.24
 
   '@astrojs/telemetry@3.1.0':
     resolution: {integrity: sha512-/ca/+D8MIKEC8/A9cSaPUqQNZm+Es/ZinRv0ZAzvu2ios7POQSsVD+VOj7/hypWNsNM3T7RpfgNq7H2TU1KEHA==}
@@ -2597,10 +2578,6 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
-  lilconfig@3.1.2:
-    resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
-    engines: {node: '>=14'}
-
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -3271,18 +3248,6 @@ packages:
 
   postcss-load-config@4.0.1:
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
     engines: {node: '>= 14'}
     peerDependencies:
       postcss: '>=8.0.9'
@@ -4067,11 +4032,6 @@ packages:
     resolution: {integrity: sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==}
     engines: {node: '>= 14'}
 
-  yaml@2.5.0:
-    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4171,12 +4131,6 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.23.8
 
-  '@astrojs/starlight-tailwind@2.0.3(@astrojs/starlight@0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2)))(@astrojs/tailwind@5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3))(tailwindcss@3.3.3)':
-    dependencies:
-      '@astrojs/starlight': 0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))
-      '@astrojs/tailwind': 5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3)
-      tailwindcss: 3.3.3
-
   '@astrojs/starlight@0.26.1(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))':
     dependencies:
       '@astrojs/mdx': 3.1.3(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))
@@ -4203,16 +4157,6 @@ snapshots:
       vfile: 6.0.2
     transitivePeerDependencies:
       - supports-color
-
-  '@astrojs/tailwind@5.1.0(astro@4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2))(tailwindcss@3.3.3)':
-    dependencies:
-      astro: 4.14.2(@types/node@20.5.7)(rollup@4.21.0)(typescript@5.2.2)
-      autoprefixer: 10.4.16(postcss@8.4.29)
-      postcss: 8.4.29
-      postcss-load-config: 4.0.2(postcss@8.4.29)
-      tailwindcss: 3.3.3
-    transitivePeerDependencies:
-      - ts-node
 
   '@astrojs/telemetry@3.1.0':
     dependencies:
@@ -6796,8 +6740,6 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
-  lilconfig@3.1.2: {}
-
   lines-and-columns@1.2.4: {}
 
   load-yaml-file@0.2.0:
@@ -8040,13 +7982,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.29
 
-  postcss-load-config@4.0.2(postcss@8.4.29):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.5.0
-    optionalDependencies:
-      postcss: 8.4.29
-
   postcss-nested@6.0.1(postcss@8.4.29):
     dependencies:
       postcss: 8.4.29
@@ -9039,8 +8974,6 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.3.1: {}
-
-  yaml@2.5.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
Last PR of the day for me

This contains:
- fix for rollup so that astro can build (the error is visible here: https://github.com/ada-url/website/pull/102#issuecomment-2295336210)
- add more ignore in biome so that it won't run in the Astro's generated assets
- a bit unrelated, but we were applying the `biome format` checks twice (as `biome check` already runs `biome format`, see https://biomejs.dev/reference/cli/#biome-format)